### PR TITLE
Fix/handle routing better

### DIFF
--- a/config/config.dev.json
+++ b/config/config.dev.json
@@ -1,4 +1,7 @@
 {
+  "app": {
+    "basePath": "/"
+  },
   "firebase": {
     "projectId": "mloureiro-lunch-time-dev",
     "authDomain": "mloureiro-lunch-time-dev.firebaseapp.com",

--- a/config/config.prod.json
+++ b/config/config.prod.json
@@ -1,4 +1,7 @@
 {
+  "app": {
+    "basePath": "lunch-time"
+  },
   "firebase": {
     "projectId": "mloureiro-lunch-time",
     "authDomain": "mloureiro-lunch-time.firebaseapp.com",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import LoginPage from './pages/LoginPage';
 import NotFound from './pages/NotFound';
 import registerServiceWorker from './registerServiceWorker';
 import theme from './theme.style';
+import { app as config } from './config.json';
 import './index.css';
 
 const AppWrapper = styled.section`
@@ -33,7 +34,7 @@ class App extends Component {
 }
 
 const app = (
-  <BrowserRouter>
+  <BrowserRouter basename={config.basePath}>
     <ThemeProvider theme={theme}>
       <App />
     </ThemeProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 import LandingPage from './pages/LandingPage';
 import LoginPage from './pages/LoginPage';
+import NotFound from './pages/NotFound';
 import registerServiceWorker from './registerServiceWorker';
 import theme from './theme.style';
-import { auth, isAuthenticated, userIdManager } from './services/auth/user';
 import './index.css';
 
 const AppWrapper = styled.section`
@@ -18,31 +18,14 @@ const AppWrapper = styled.section`
   font-size: ${({ theme }) => theme.general.font.size};
 `;
 
-function LoginRoute () {
-  return (
-    <Route
-      exact
-      path="/login"
-      render={renderProps => (
-        !isAuthenticated() ? (
-          <LoginPage />
-        ) : (
-          <Redirect to="/" />
-        )
-      )}
-    />
-  )
-}
-
 class App extends Component {
-
   render() {
     return (
       <AppWrapper>
         <Switch>
           <Route exact path="/" component={LandingPage} />
-          <LoginRoute />
-          <Redirect to="/" />
+          <Route exact path="/login" component={LoginPage} />
+          <Route component={NotFound} />
         </Switch>
       </AppWrapper>
     );

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+`;
+
+const Title = styled.h3`
+  font-size: 3em;
+  margin: 0;
+  padding: 0;
+`;
+
+const Error = styled.h1`
+  color: #9b0000;
+  font-size: 5em;
+  margin: 0;
+  padding: 0;
+`;
+
+export default function NotFound() {
+  return (
+    <Wrapper>
+      <Error>404</Error>
+      <Title>You lost?</Title>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
Due to the GH pages not using the `/` root but instead the project name `/lunch-time`, BrowserRouter wasn't matching the path giving a blank page.

- [x] make 404 page (to avoid mismatch)
- [x] fix path prefix